### PR TITLE
Enable github enterprise

### DIFF
--- a/gitops/git/github/github.go
+++ b/gitops/git/github/github.go
@@ -15,7 +15,7 @@ var (
 	repoOwner = flag.String("github_repo_owner", "", "the owner user/organization to use for github api requests")
 	repo = flag.String("github_repo", "", "the repo to use for github api requests")
 	pat = flag.String("github_access_token", os.Getenv("GITHUB_TOKEN"), "the access token to authenticate requests")
-	githubHost = flag.String("github_host", "", "The host name of the private enterprise github, e.g. git.corp.adobe.com")
+	githubEnterpriseHost = flag.String("github_enterprise_host", "", "The host name of the private enterprise github, e.g. git.corp.adobe.com")
 )
 
 func CreatePR(from, to, title string) error {
@@ -34,16 +34,19 @@ func CreatePR(from, to, title string) error {
 		&oauth2.Token{AccessToken: *pat},
 	)
 	tc := oauth2.NewClient(ctx, ts)
-	gh := github.NewClient(tc)
-	if *githubHost != "" {
-		baseUrl := "https://" + *githubHost + "/api/v3/"
-		uploadUrl := "https://" + *githubHost + "/api/uploads/"
+
+	var gh *github.Client
+	if *githubEnterpriseHost != "" {
+		baseUrl := "https://" + *githubEnterpriseHost + "/api/v3/"
+		uploadUrl := "https://" + *githubEnterpriseHost + "/api/uploads/"
 		var err error
 		gh, err = github.NewEnterpriseClient(baseUrl, uploadUrl, tc)
 		if err != nil {
 			log.Println("Error in creating github client", err)
 			return nil
 		}
+	} else {
+		gh = github.NewClient(tc)
 	}
 
 	pr := &github.NewPullRequest{

--- a/gitops/git/github/github.go
+++ b/gitops/git/github/github.go
@@ -60,7 +60,6 @@ func CreatePR(from, to, title string) error {
 	}
 	createdPr, resp, err := gh.PullRequests.Create(ctx, *repoOwner, *repo, pr)
 	if err == nil {
-		// PR created
 		log.Println("Created PR: ", *createdPr.URL)
 	} else if 422 == resp.StatusCode {
 		// Handle the case: "Create PR" request fails because it already exists
@@ -72,8 +71,9 @@ func CreatePR(from, to, title string) error {
 		body, readingErr := ioutil.ReadAll(resp.Body)
 		if readingErr != nil {
 			log.Println("cannot read response body")
+		} else {
+			log.Println("github response: ", string(body))
 		}
-		log.Println("github response: ", string(body))
 	}
 
 	return err

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -33,6 +33,10 @@ import (
 	proto "github.com/golang/protobuf/proto"
 )
 
+func init() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
+
 var (
 	releaseBranch          = flag.String("release_branch", "master", "filter gitops targets by release branch")
 	bazelCmd               = flag.String("bazel_cmd", "tools/bazel", "bazel binary to use")
@@ -148,6 +152,7 @@ func main() {
 		for _, target := range targets {
 			log.Println("train", train, "target", target)
 			bin := bazel.TargetToExecutable(target)
+			exec.Mustex("", "bazel", "build", target)
 			exec.Mustex("", bin, "--nopush", "--nobazel", "--deployment_root", gitopsdir)
 		}
 		if workdir.Commit(fmt.Sprintf("GitOps for release branch %s from %s commit %s\n%s", *releaseBranch, *branchName, *gitCommit, commitmsg.Generate(targets)), *gitopsPath) {

--- a/gitops/prer/create_gitops_prs.go
+++ b/gitops/prer/create_gitops_prs.go
@@ -152,7 +152,6 @@ func main() {
 		for _, target := range targets {
 			log.Println("train", train, "target", target)
 			bin := bazel.TargetToExecutable(target)
-			exec.Mustex("", "bazel", "build", target)
 			exec.Mustex("", bin, "--nopush", "--nobazel", "--deployment_root", gitopsdir)
 		}
 		if workdir.Commit(fmt.Sprintf("GitOps for release branch %s from %s commit %s\n%s", *releaseBranch, *branchName, *gitCommit, commitmsg.Generate(targets)), *gitopsPath) {


### PR DESCRIPTION

When `:create_gitops_prs` is run once and there are subsequent changes, i.e. gitops result will be expected to be different, this would lead to noops.

```
exec.Mustex("", bin, "--nopush", "--nobazel", "--deployment_root", gitopsdir)
<--->
2021/04/11 10:26:16 exec.go:22: executing: bazel-bin/apps/deployments/docengineservice/docengineservice-ccweb-preview.gitops --nopush --nobazel --deployment_root /var/folders/qy/kldjxbhx6gs4v1rc2n00q3840000gq/T/gitops790537687
```

Adding `exec.Mustex("", "bazel", "build", target)` ensure that the new gitops target is built with the latest source files.



---
```
2021/04/11 10:32:12 create_gitops_prs.go:228: unable to create PR: http: read on closed response body
```



